### PR TITLE
chore: add request id to the link operation

### DIFF
--- a/operation-dispatcher/index.js
+++ b/operation-dispatcher/index.js
@@ -56,12 +56,12 @@ module.exports.webhookJob = async function webhookJob(Link, User, WebhookQueue, 
 
     // Link hasn't been synced, ever, since no 'last sha' value is present. Sync it.
     } else if (!link.upstreamLastSHA) {
-      await WebhookQueue.push({type: AUTOMATIC, user: link.owner, link});
+      await WebhookQueue.push({type: AUTOMATIC, user: link.owner, link, fromRequest: null});
       debug(`Update enqueued successfully for link %o. REASON = FIRST_SYNC`, link.id);
 
     // The upstream has new commits since the last polling attempt. Sync it.
     } else if (link.upstreamLastSHA !== headSha) {
-      await WebhookQueue.push({type: AUTOMATIC, user: link.owner, link});
+      await WebhookQueue.push({type: AUTOMATIC, user: link.owner, link, fromRequest: null});
       debug(`Update enqueued successfully for link %o. REASON = UPSTREAM_NEW_COMMITS`, link.id);
 
     } else {

--- a/operation-dispatcher/test.js
+++ b/operation-dispatcher/test.js
@@ -84,6 +84,7 @@ describe('webhook dispatcher job', function() {
     assert.equal(MockWebhookQueue.queue[0].item.type, 'AUTOMATIC');
     assert.equal(MockWebhookQueue.queue[0].item.link.id, link.id);
     assert.equal(MockWebhookQueue.queue[0].item.user.id, link.ownerId);
+    assert.equal(MockWebhookQueue.queue[0].item.fromRequest, null);
 
     // And the last synced time was updated.
     assert.notEqual((await Link.findById(link.id)).lastSyncedAt, LONG_TIME_AGO);
@@ -99,6 +100,7 @@ describe('webhook dispatcher job', function() {
     assert.equal(MockWebhookQueue.queue[0].item.type, 'AUTOMATIC');
     assert.equal(MockWebhookQueue.queue[0].item.link.id, linkExistingUpstreamSHA.id);
     assert.equal(MockWebhookQueue.queue[0].item.user.id, linkExistingUpstreamSHA.ownerId);
+    assert.equal(MockWebhookQueue.queue[0].item.fromRequest, null);
 
     // And the last synced time was updated.
     assert.notEqual((await Link.findById(linkExistingUpstreamSHA.id)).lastSyncedAt, LONG_TIME_AGO);


### PR DESCRIPTION
Automatic updates should be given a `fromRequest` property of `null` because they weren't spawned from a request.